### PR TITLE
Add new APIs to re-enable hardware blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ pwr.disable_while_sleeping_all_but(
     pwr.EN0_CLK_SYS_PLL_USB
 )
 ```
+* pwr.enable_while_sleeping() - arguments to this function are hardware blocks you want enabled when sleeping.
+Hardware blocks you do not list are unchanged.
+You can call this function more than once.
+Note: If the argument is empty list no changes are made.
+This function is not that useful. Included for testing.
+```
+pwr.enable_while_sleeping(
+    pwr.EN0_CLK_SYS_SPI1,
+    pwr.EN0_CLK_PERI_SPI
+)
+
+```
 
 There are two similar functions to disable hardware blocks while sleeping:
 * pwr.disable_while_awake() - arguments to this function are hardware blocks you want disabled when sleeping.
@@ -123,6 +135,18 @@ pwr.disable_while_awake_all_but(
     pwr.EN0_CLK_SYS_I2C1,
     pwr.EN0_CLK_SYS_I2C0
 )
+```
+* pwr.enable_while_awake() - arguments to this function are hardware blocks you want enabled when awake.
+Hardware blocks you do not list are unchanged.
+You can call this function more than once.
+Note: If the argument is empty list no changes are made.
+This function is useful when there is a hardware block you only need occasionally.
+```
+pwr.enable_while_awake(
+    pwr.EN0_CLK_SYS_SPI1,
+    pwr.EN0_CLK_PERI_SPI
+)
+
 ```
 
 The values specified in argument list are constants defined in the PowerCtrl object.

--- a/power_ctrl_abstract.py
+++ b/power_ctrl_abstract.py
@@ -27,6 +27,24 @@ class PowerCtrlAbstract :
         mem32[self.__SLEEP_EN0] &= ~mask0
         mem32[self.__SLEEP_EN1] &= ~mask1
         
+    # Enable specified hardware blocks while RP2 is sleeping.
+    # If called with no arguments does nothing.
+    #
+    # Note: Not that useful.
+    # Typically users disable given hardware blocks and leave it that way forever.
+    
+    def enable_while_sleeping(self, *args) :
+        mask0 = 0
+        mask1 = 0
+        for arg in args :
+            if arg >= 32 :
+                mask1 |= 1 << (arg - 32)
+            else :
+                mask0 |= 1 << arg
+                
+        mem32[self.__SLEEP_EN0] |= mask0
+        mem32[self.__SLEEP_EN1] |= mask1
+        
     # Disable all but the specified hardware blocks while RP2 is sleeping.
     # If called with no argumentss will disable all hardware blocks.
 
@@ -57,6 +75,24 @@ class PowerCtrlAbstract :
 
         mem32[self.__WAKE_EN0] &= ~mask0
         mem32[self.__WAKE_EN1] &= ~mask1
+        
+    # Enable specified hardware blocks while RP2 is
+    # awake (at least one core running or DMA active),
+    # If called with no arguments does nothing.
+    #
+    # Note: Useful if given hardware blocks are needed occasionally.
+
+    def enable_while_awake(self, *args) :
+        mask0 = 0
+        mask1 = 0
+        for arg in args :
+            if arg >= 32 :
+                mask1 |= 1 << (arg - 32)
+            else :
+                mask0 |= 1 << arg
+
+        mem32[self.__WAKE_EN0] |= mask0
+        mem32[self.__WAKE_EN1] |= mask1
         
     # Disable all but the specified hardware blocks while RP2 is
     # awake(at least one core running or DMA active),


### PR DESCRIPTION
Adding two new API's to enable one or more hardware blocks.

enable_while_sleeping() - not of real value. Implemented for completeness only.

enable_while_awake() - supports powering up a hardware block that is rarely needed.